### PR TITLE
コミットメッセージに `[skip ci]` が含まれていた場合はCIを実行しない

### DIFF
--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -13,6 +13,7 @@ concurrency: preview-${{ github.ref }}
 jobs:
   deploy-preview:
     runs-on: ubuntu-latest
+    if: ${{ !startsWith(github.event.commits.*.message, '[skip ci]') || github.ref == 'refs/heads/main' }}
     steps:
       - name: Checkout
         uses: actions/checkout@v4


### PR DESCRIPTION
コミットメッセージに `[skip ci]` が含まれていた場合はCIを実行しない。